### PR TITLE
Disable InvalidPackage lint for Okio and Retrofit

### DIFF
--- a/GithubBrowserSample/app/build.gradle
+++ b/GithubBrowserSample/app/build.gradle
@@ -48,7 +48,7 @@ android {
         test.java.srcDirs += "src/test-common/java"
     }
     lintOptions {
-        disable 'GoogleAppIndexingWarning'
+        lintConfig rootProject.file('lint.xml')
     }
 }
 

--- a/GithubBrowserSample/lint.xml
+++ b/GithubBrowserSample/lint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="GoogleAppIndexWarning" severity="ignore" />
+
+    <issue id="InvalidPackage" severity="error">
+        <ignore regexp="okio.*jar" />
+        <ignore regexp="retrofit.*jar" />
+    </issue>
+</lint>
+


### PR DESCRIPTION
Okio references `java.nio.file`, which does not exist on Android prior to O.  Retrofit also references invalid packages.

This PR moves lint config to an XML file that ignores InvalidPackage from those two libraries, while remaining an error everywhere else.

Fixes #10