### PR TITLE
Fixed double-checked locking patterns by using volatile

### DIFF
--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.java
@@ -27,7 +27,7 @@ import android.content.Context;
 @Database(entities = {User.class}, version = 1)
 public abstract class UsersDatabase extends RoomDatabase {
 
-    private static UsersDatabase INSTANCE;
+    private static volatile UsersDatabase INSTANCE;
 
     public abstract UserDao userDao();
 

--- a/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.kt
+++ b/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/persistence/UsersDatabase.kt
@@ -31,10 +31,10 @@ abstract class UsersDatabase : RoomDatabase() {
 
     companion object {
 
-        private var INSTANCE: UsersDatabase? = null
+        @Volatile private var INSTANCE: UsersDatabase? = null
 
         fun getInstance(context: Context): UsersDatabase =
-                INSTANCE ?: synchronized(UsersDatabase::class) {
+                INSTANCE ?: synchronized(this) {
                     INSTANCE ?: buildDatabase(context).also { INSTANCE = it }
                 }
 

--- a/PersistenceMigrationsSample/app/src/room_common/java/com/example/android/persistence/migrations/LocalUserDataSource.java
+++ b/PersistenceMigrationsSample/app/src/room_common/java/com/example/android/persistence/migrations/LocalUserDataSource.java
@@ -25,7 +25,7 @@ import android.support.annotation.VisibleForTesting;
  */
 public class LocalUserDataSource implements UserDataSource {
 
-    private static LocalUserDataSource INSTANCE;
+    private static volatile LocalUserDataSource INSTANCE;
 
     private UserDao mUserDao;
 


### PR DESCRIPTION
Double-checked locking requires the checked variable to be declared as `volatile` in order to prevent the JVM from reordering reads and breaking the algorithm.

In addition, the Kotlin code synchronizes on the companion object instance, which is a more natural way to synchronize pseudo-static methods in Kotlin.