### PR TITLE
BasicRxJavaSampleKotlin: alternative fix to ArgumentCaptor.capture().

### DIFF
--- a/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt
+++ b/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt
@@ -32,14 +32,11 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class UserDaoTest {
 
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private lateinit var database: UsersDatabase
 
-    @Before
-    @Throws(Exception::class)
-    fun initDb() {
+    @Before fun initDb() {
         // using an in-memory database because the information stored here disappears after test
         database = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
                 UsersDatabase::class.java)
@@ -48,21 +45,17 @@ class UserDaoTest {
                 .build()
     }
 
-    @After
-    @Throws(Exception::class)
-    fun closeDb() {
+    @After fun closeDb() {
         database.close()
     }
 
-    @Test
-    fun getUsersWhenNoUserInserted() {
+    @Test fun getUsersWhenNoUserInserted() {
         database.userDao().getUserById("123")
                 .test()
                 .assertNoValues()
     }
 
-    @Test
-    fun insertAndGetUser() {
+    @Test fun insertAndGetUser() {
         // When inserting a new user in the data source
         database.userDao().insertUser(USER)
 
@@ -73,8 +66,7 @@ class UserDaoTest {
                 .assertValue { it.id == USER.id && it.userName == USER.userName }
     }
 
-    @Test
-    fun updateAndGetUser() {
+    @Test fun updateAndGetUser() {
         // Given that we have a user in the data source
         database.userDao().insertUser(USER)
 
@@ -89,8 +81,7 @@ class UserDaoTest {
                 .assertValue { it.id == USER.id && it.userName == "new username" }
     }
 
-    @Test
-    fun deleteAndGetUser() {
+    @Test fun deleteAndGetUser() {
         // Given that we have a user in the data source
         database.userDao().insertUser(USER)
 

--- a/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/MockitoKotlinHelpers.kt
+++ b/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/MockitoKotlinHelpers.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.android.observability
+
+import org.mockito.ArgumentCaptor
+
+/**
+ * Returns ArgumentCaptor.capture() as nullable type to avoid java.lang.IllegalStateException
+ * when null is returned.
+ */
+fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()

--- a/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt
+++ b/BasicRxJavaSampleKotlin/app/src/test/java/com/example/android/observability/UserViewModelTest.kt
@@ -38,28 +38,21 @@ import org.mockito.MockitoAnnotations
  */
 class UserViewModelTest {
 
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule var instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    @Mock
-    private lateinit var dataSource: UserDao
+    @Mock private lateinit var dataSource: UserDao
 
-    @Captor
-    private lateinit var userArgumentCaptor: ArgumentCaptor<User>
+    @Captor private lateinit var userArgumentCaptor: ArgumentCaptor<User>
 
     private lateinit var viewModel: UserViewModel
 
-    @Before
-    @Throws(Exception::class)
-    fun setUp() {
+    @Before fun setUp() {
         MockitoAnnotations.initMocks(this)
 
         viewModel = UserViewModel(dataSource)
     }
 
-    @Test
-    @Throws(InterruptedException::class)
-    fun getUserName_whenNoUserSaved() {
+    @Test fun getUserName_whenNoUserSaved() {
         // Given that the UserDataSource returns an empty list of users
         `when`(dataSource.getUserById(UserViewModel.USER_ID)).thenReturn(Flowable.empty<User>())
 
@@ -70,9 +63,7 @@ class UserViewModelTest {
                 .assertNoValues()
     }
 
-    @Test
-    @Throws(InterruptedException::class)
-    fun getUserName_whenUserSaved() {
+    @Test fun getUserName_whenUserSaved() {
         // Given that the UserDataSource returns a user
         val user = User(userName = "user name")
         `when`(dataSource.getUserById(UserViewModel.USER_ID)).thenReturn(Flowable.just(user))
@@ -84,8 +75,7 @@ class UserViewModelTest {
                 .assertValue("user name")
     }
 
-    @Test
-    fun updateUserName_updatesNameInDataSource() {
+    @Test fun updateUserName_updatesNameInDataSource() {
         // When updating the user name
         viewModel.updateUserName("new user name")
                 .test()
@@ -94,8 +84,7 @@ class UserViewModelTest {
         // The user name is updated in the data source
         // using ?: User("someUser") because otherwise, we get
         // "IllegalStateException: userArgumentCaptor.capture() must not be null"
-        verify<UserDao>(dataSource).insertUser(userArgumentCaptor.capture()
-                ?: User(userName = "someUser"))
+        verify<UserDao>(dataSource).insertUser(capture(userArgumentCaptor))
         assertThat(userArgumentCaptor.value.userName, Matchers.`is`("new user name"))
     }
 


### PR DESCRIPTION
* Uses a wrapper function for ArgumentCaptor.capture() that avoids an IllegalStateException.
* Also, nit style change to annotations.