### PR TITLE
Fix page matching pattern.

### DIFF
--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/api/ApiResponse.java
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/api/ApiResponse.java
@@ -36,7 +36,7 @@ import timber.log.Timber;
 public class ApiResponse<T> {
     private static final Pattern LINK_PATTERN = Pattern
             .compile("<([^>]*)>[\\s]*;[\\s]*rel=\"([a-zA-Z0-9]+)\"");
-    private static final Pattern PAGE_PATTERN = Pattern.compile("page=(\\d)+");
+    private static final Pattern PAGE_PATTERN = Pattern.compile("\\bpage=(\\d+)");
     private static final String NEXT_LINK = "next";
     public final int code;
     @Nullable


### PR DESCRIPTION
Now correctly handles multiple character pages, and doesn't
incorrectly match "per_page", if that's used to choose page size.