### PR TITLE
Fix espresso tests on lollipop

### DIFF
--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.java
@@ -16,10 +16,34 @@
 
 package com.android.example.github.ui.repo;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.arch.lifecycle.MutableLiveData;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
 import com.android.example.github.R;
 import com.android.example.github.binding.FragmentBindingAdapters;
 import com.android.example.github.testing.SingleFragmentActivity;
 import com.android.example.github.ui.common.NavigationController;
+import com.android.example.github.util.EspressoTestUtil;
 import com.android.example.github.util.RecyclerViewMatcher;
 import com.android.example.github.util.TaskExecutorWithIdlingResourceRule;
 import com.android.example.github.util.TestUtil;
@@ -33,30 +57,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.CoreMatchers.not;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class RepoFragmentTest {
@@ -88,7 +90,7 @@ public class RepoFragmentTest {
         repoFragment.viewModelFactory = ViewModelUtil.createFor(viewModel);
         repoFragment.dataBindingComponent = () -> fragmentBindingAdapters;
         repoFragment.navigationController = navigationController;
-
+        EspressoTestUtil.disableProgressBarAnimations(activityRule);
         activityRule.getActivity().setFragment(repoFragment);
     }
 

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/search/SearchFragmentTest.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/search/SearchFragmentTest.java
@@ -16,10 +16,37 @@
 
 package com.android.example.github.ui.search;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.pressKey;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.arch.lifecycle.MutableLiveData;
+import android.support.annotation.NonNull;
+import android.support.test.espresso.contrib.RecyclerViewActions;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.KeyEvent;
+
 import com.android.example.github.R;
 import com.android.example.github.binding.FragmentBindingAdapters;
 import com.android.example.github.testing.SingleFragmentActivity;
 import com.android.example.github.ui.common.NavigationController;
+import com.android.example.github.util.EspressoTestUtil;
 import com.android.example.github.util.RecyclerViewMatcher;
 import com.android.example.github.util.TaskExecutorWithIdlingResourceRule;
 import com.android.example.github.util.TestUtil;
@@ -32,34 +59,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
-import android.support.test.InstrumentationRegistry;
-import android.support.test.espresso.contrib.RecyclerViewActions;
-import android.support.test.espresso.matcher.ViewMatchers;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-import android.view.KeyEvent;
-
 import java.util.Arrays;
 import java.util.List;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.action.ViewActions.pressKey;
-import static android.support.test.espresso.action.ViewActions.typeText;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.CoreMatchers.not;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class SearchFragmentTest {
@@ -90,6 +91,7 @@ public class SearchFragmentTest {
         searchFragment.viewModelFactory = ViewModelUtil.createFor(viewModel);
         searchFragment.dataBindingComponent = () -> fragmentBindingAdapters;
         searchFragment.navigationController = navigationController;
+        EspressoTestUtil.disableProgressBarAnimations(activityRule);
         activityRule.getActivity().setFragment(searchFragment);
     }
 

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/user/UserFragmentTest.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/user/UserFragmentTest.java
@@ -16,10 +16,32 @@
 
 package com.android.example.github.ui.user;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.arch.lifecycle.MutableLiveData;
+import android.support.annotation.NonNull;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
 import com.android.example.github.R;
 import com.android.example.github.binding.FragmentBindingAdapters;
 import com.android.example.github.testing.SingleFragmentActivity;
 import com.android.example.github.ui.common.NavigationController;
+import com.android.example.github.util.EspressoTestUtil;
 import com.android.example.github.util.RecyclerViewMatcher;
 import com.android.example.github.util.TestUtil;
 import com.android.example.github.util.ViewModelUtil;
@@ -32,28 +54,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.arch.lifecycle.MutableLiveData;
-import android.support.annotation.NonNull;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.action.ViewActions.click;
-import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withId;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
-import static org.hamcrest.CoreMatchers.not;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class UserFragmentTest {
@@ -83,6 +85,7 @@ public class UserFragmentTest {
 
         activityRule.getActivity().setFragment(fragment);
         activityRule.runOnUiThread(() -> fragment.binding.get().repoList.setItemAnimator(null));
+        EspressoTestUtil.disableProgressBarAnimations(activityRule);
     }
 
     @Test

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/EspressoTestUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.example.github.util;
+
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Bundle;
+import android.support.test.rule.ActivityTestRule;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ProgressBar;
+
+/**
+ * Utility methods for espresso tests.
+ */
+public class EspressoTestUtil {
+    /**
+     * Disables progress bar animations for the views of the given activity rule
+     *
+     * @param activityTestRule The activity rule whose views will be checked
+     */
+    public static void disableProgressBarAnimations(
+            ActivityTestRule<? extends FragmentActivity> activityTestRule) {
+        activityTestRule.getActivity().getSupportFragmentManager()
+                .registerFragmentLifecycleCallbacks(
+                new FragmentManager.FragmentLifecycleCallbacks() {
+                    @Override
+                    public void onFragmentViewCreated(FragmentManager fm, Fragment f, View v,
+                            Bundle savedInstanceState) {
+                        // traverse all views, if any is a progress bar, replace its animation
+                        traverseViews(v);
+                    }
+                }, true);
+    }
+
+    private static void traverseViews(View view) {
+        if (view instanceof ViewGroup) {
+            traverseViewGroup((ViewGroup) view);
+        } else {
+            if (view instanceof ProgressBar) {
+                disableProgressBarAnimation((ProgressBar) view);
+            }
+        }
+    }
+
+    private static void traverseViewGroup(ViewGroup view) {
+        final int count = view.getChildCount();
+        for (int i = 0; i < count; i++) {
+            traverseViews(view.getChildAt(i));
+        }
+    }
+
+    /**
+     * necessary to run tests on older API levels where progress bar uses handler loop to animate.
+     *
+     * @param progressBar The progress bar whose animation will be swapped with a drawable
+     */
+    private static void disableProgressBarAnimation(ProgressBar progressBar) {
+        progressBar.setIndeterminateDrawable(new ColorDrawable(Color.BLUE));
+    }
+}


### PR DESCRIPTION
This CL disables the animation in progress bars so that espresso can
detect idle on older platforms