### PR TITLE
Remove usage of internal rxjava classes

### DIFF
--- a/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/UserViewModel.java
+++ b/BasicRxJavaSample/app/src/main/java/com/example/android/observability/ui/UserViewModel.java
@@ -17,15 +17,10 @@
 package com.example.android.observability.ui;
 
 import android.arch.lifecycle.ViewModel;
-
 import com.example.android.observability.UserDataSource;
 import com.example.android.observability.persistence.User;
-
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
-import io.reactivex.functions.Action;
-import io.reactivex.functions.Function;
-import io.reactivex.internal.operators.completable.CompletableFromAction;
 
 /**
  * View Model for the {@link UserActivity}
@@ -62,7 +57,7 @@ public class UserViewModel extends ViewModel {
      * @return a {@link Completable} that completes when the user name is updated
      */
     public Completable updateUserName(final String userName) {
-        return new CompletableFromAction(() -> {
+        return Completable.fromAction(() -> {
             // if there's no use, create a new user.
             // if we already have a user, then, since the user object is immutable,
             // create a new user, with the id of the previous user and the updated user name.

--- a/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt
+++ b/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt
@@ -45,10 +45,10 @@ class UserViewModel(private val dataSource: UserDao) : ViewModel() {
      * @return a [Completable] that completes when the user name is updated
      */
     fun updateUserName(userName: String): Completable {
-        return Completable.fromAction({
+        return Completable.fromAction {
             val user = User(USER_ID, userName)
             dataSource.insertUser(user)
-        })
+        }
     }
 
     companion object {

--- a/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt
+++ b/BasicRxJavaSampleKotlin/app/src/main/java/com/example/android/observability/ui/UserViewModel.kt
@@ -21,8 +21,6 @@ import com.example.android.observability.persistence.User
 import com.example.android.observability.persistence.UserDao
 import io.reactivex.Completable
 import io.reactivex.Flowable
-import io.reactivex.functions.Action
-import io.reactivex.internal.operators.completable.CompletableFromAction
 
 /**
  * View Model for the [UserActivity]
@@ -47,7 +45,7 @@ class UserViewModel(private val dataSource: UserDao) : ViewModel() {
      * @return a [Completable] that completes when the user name is updated
      */
     fun updateUserName(userName: String): Completable {
-        return CompletableFromAction(Action {
+        return Completable.fromAction({
             val user = User(USER_ID, userName)
             dataSource.insertUser(user)
         })


### PR DESCRIPTION
BasicRxJavaSample and BasicRxJavaSampleKotlin use io.reactivex.internal.operators.completable.CompletableFromAction from rxjavas internal package, this uses  Completable.fromAction from the public API instead.