### PR TITLE
Removed deprecated interface LifecycleRegistryOwner.

### DIFF
--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.java
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.java
@@ -46,7 +46,7 @@ import javax.inject.Inject;
 /**
  * The UI Controller for displaying a Github Repo's information with its contributors.
  */
-public class RepoFragment extends Fragment implements LifecycleRegistryOwner, Injectable {
+public class RepoFragment extends Fragment implements Injectable {
 
     private static final String REPO_OWNER_KEY = "repo_owner";
 


### PR DESCRIPTION
LifecycleRegistryOwner was deprecated in release 1.1.0.