### PR TITLE
Improve LiveData thread execution

### DIFF
--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.java
@@ -24,7 +24,7 @@ import android.arch.persistence.room.Room;
 import android.support.test.InstrumentationRegistry;
 
 abstract public class DbTest {
-    protected GithubDb db;
+    GithubDb db;
 
     @Before
     public void initDb() {

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.java
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.java
@@ -17,19 +17,32 @@
 package com.android.example.github.db;
 
 
-import org.junit.After;
-import org.junit.Before;
-
+import android.arch.core.executor.testing.InstantTaskExecutorRule;
 import android.arch.persistence.room.Room;
 import android.support.test.InstrumentationRegistry;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+
+import java.util.concurrent.TimeUnit;
+
 abstract public class DbTest {
+
+    @Rule
+    public InstantTaskExecutorRule instantExecutorRule = new InstantTaskExecutorRule();
+
+    @Rule
+    public Timeout timeout = new Timeout(4, TimeUnit.SECONDS);
+
     GithubDb db;
 
     @Before
     public void initDb() {
-        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
-                GithubDb.class).build();
+        db = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(), GithubDb.class)
+                .allowMainThreadQueries()
+                .build();
     }
 
     @After

--- a/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/LiveDataTestUtil.java
+++ b/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/LiveDataTestUtil.java
@@ -24,19 +24,24 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class LiveDataTestUtil {
+
+    /**
+     * Observes and returns the value of {@code liveData}. Note that this method is not thread-safe
+     * and will probably return null when {@code liveData} executes tasks on another thread. Add
+     * {@link android.arch.core.executor.testing.InstantTaskExecutorRule} to your tests in order to
+     * run everything on the same thread.
+     * @param liveData The {@link LiveData} to observe
+     */
     public static <T> T getValue(LiveData<T> liveData) throws InterruptedException {
         final Object[] data = new Object[1];
-        CountDownLatch latch = new CountDownLatch(1);
         Observer<T> observer = new Observer<T>() {
             @Override
             public void onChanged(@Nullable T o) {
                 data[0] = o;
-                latch.countDown();
                 liveData.removeObserver(this);
             }
         };
         liveData.observeForever(observer);
-        latch.await(2, TimeUnit.SECONDS);
         //noinspection unchecked
         return (T) data[0];
     }


### PR DESCRIPTION
- Adds the ability to change the default ThreadExecutor which is useful for testing
- LiveData objects by Retrofit let ArchTaskExecutor decide on which thread to run
- Removed redundant CountDownLatch and potential bug
- Code cleaning 😃 