### PR TITLE
Update versions.support and versions.paging.

### DIFF
--- a/PagingWithNetworkSample/versions.gradle
+++ b/PagingWithNetworkSample/versions.gradle
@@ -26,7 +26,7 @@ def versions = [:]
 versions.arch_core = "1.1.0"
 versions.room = "1.1.0-alpha1"
 versions.lifecycle = "1.1.0"
-versions.support = "26.1.0"
+versions.support = "27.1.0"
 versions.dagger = "2.11"
 versions.junit = "4.12"
 versions.espresso = "3.0.1"
@@ -47,7 +47,7 @@ versions.atsl_runner = "1.0.1"
 versions.atsl_rules = "1.0.1"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.2.20"
-versions.paging = "1.0.0-alpha5"
+versions.paging = "1.0.0-alpha6"
 def deps = [:]
 
 def support = [:]


### PR DESCRIPTION
The code in this project was previously updated to use support library version 27.1.0 and paging library 1.0.0-alpha6 (see pull request https://github.com/googlesamples/android-architecture-components/pull/315).

However the versions.gradle currently still references the older versions of those libraries, making the project uncompilable.