### PR TITLE
Fix a crash on search

### DIFF
--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchFragment.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/search/SearchFragment.kt
@@ -107,7 +107,7 @@ class SearchFragment : Fragment(), Injectable {
     }
 
     private fun initSearchInputListener() {
-        binding.input.setOnEditorActionListener { view: View, actionId: Int, _: KeyEvent ->
+        binding.input.setOnEditorActionListener { view: View, actionId: Int, _: KeyEvent? ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH) {
                 doSearch(view)
                 true


### PR DESCRIPTION
Resolve #347 

This PR fixes crash in one place but I guess the issue could arise somewhere else too.

I think the more general fix would be removing explicit types in lambdas. In that case, `Java` classes will be used as nullable automatically.

Thoughts?