### PR TITLE
fix_crash_while_navigationing_to_Leaderboard

### DIFF
--- a/NavigationBasicSample/app/src/main/res/layout/fragment_leaderboard.xml
+++ b/NavigationBasicSample/app/src/main/res/layout/fragment_leaderboard.xml
@@ -22,7 +22,7 @@
     android:id="@+id/leaderboard_list"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    app:layoutManager="android.support.v7.widget.LinearLayoutManager"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Gradle file has been changed to androidX , but "fragment_leaderboard.xml" still imports earlier version's package . So the app will crash while navigationing to "Leaderboard" , this PR fixes it.