### PR TITLE
Update to Navigation 1.0.0-alpha09

### DIFF
--- a/BasicRxJavaSample/versions.gradle
+++ b/BasicRxJavaSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/BasicRxJavaSampleKotlin/versions.gradle
+++ b/BasicRxJavaSampleKotlin/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/BasicSample/versions.gradle
+++ b/BasicSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/GithubBrowserSample/app/build.gradle
+++ b/GithubBrowserSample/app/build.gradle
@@ -101,7 +101,6 @@ dependencies {
     androidTestImplementation deps.atsl.runner
     androidTestImplementation deps.atsl.rules
 
-    androidTestImplementation deps.navigation.testing
     androidTestImplementation deps.support.app_compat
     androidTestImplementation deps.support.recyclerview
     androidTestImplementation deps.support.cardview

--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/repo/RepoFragment.kt
@@ -91,7 +91,7 @@ class RepoFragment : Fragment(), Injectable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         repoViewModel = ViewModelProviders.of(this, viewModelFactory)
             .get(RepoViewModel::class.java)
-        val params = RepoFragmentArgs.fromBundle(arguments)
+        val params = RepoFragmentArgs.fromBundle(arguments!!)
         repoViewModel.setId(params.owner, params.name)
         binding.setLifecycleOwner(viewLifecycleOwner)
         binding.repo = repoViewModel.repo

--- a/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserFragment.kt
+++ b/GithubBrowserSample/app/src/main/java/com/android/example/github/ui/user/UserFragment.kt
@@ -74,7 +74,7 @@ class UserFragment : Fragment(), Injectable {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         userViewModel = ViewModelProviders.of(this, viewModelFactory)
             .get(UserViewModel::class.java)
-        val params = UserFragmentArgs.fromBundle(arguments)
+        val params = UserFragmentArgs.fromBundle(arguments!!)
         userViewModel.setLogin(params.login)
 
         binding.user = userViewModel.user

--- a/GithubBrowserSample/versions.gradle
+++ b/GithubBrowserSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/NavigationBasicSample/versions.gradle
+++ b/NavigationBasicSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/PagingSample/versions.gradle
+++ b/PagingSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/PagingWithNetworkSample/versions.gradle
+++ b/PagingWithNetworkSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/PersistenceContentProviderSample/versions.gradle
+++ b/PersistenceContentProviderSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/PersistenceMigrationsSample/versions.gradle
+++ b/PersistenceMigrationsSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/WorkManagerSample/versions.gradle
+++ b/WorkManagerSample/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps

--- a/versions.gradle
+++ b/versions.gradle
@@ -48,7 +48,7 @@ versions.atsl_rules = "1.1.0-alpha4"
 versions.hamcrest = "1.3"
 versions.kotlin = "1.3.0"
 versions.paging = "2.1.0-rc01"
-versions.navigation = "1.0.0-alpha08"
+versions.navigation = "1.0.0-alpha09"
 versions.work = "1.0.0-alpha13"
 def deps = [:]
 
@@ -157,7 +157,6 @@ navigation.runtime_ktx = "android.arch.navigation:navigation-runtime-ktx:$versio
 navigation.fragment = "android.arch.navigation:navigation-fragment:$versions.navigation"
 navigation.fragment_ktx = "android.arch.navigation:navigation-fragment-ktx:$versions.navigation"
 navigation.safe_args_plugin = "android.arch.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
-navigation.testing = "android.arch.navigation:navigation-testing:$versions.navigation"
 deps.navigation = navigation
 
 ext.deps = deps


### PR DESCRIPTION
Updates Args.fromBundle() calls to pass in a non-null Bundle and removed the navigation-testing artifact.

Verified via ./run_all_tests.sh