### PR TITLE
Update Room dep to 2.1.0-alpha06

### DIFF
--- a/BasicRxJavaSample/versions.gradle
+++ b/BasicRxJavaSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/BasicRxJavaSampleKotlin/versions.gradle
+++ b/BasicRxJavaSampleKotlin/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/BasicSample/versions.gradle
+++ b/BasicSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/GithubBrowserSample/versions.gradle
+++ b/GithubBrowserSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/NavigationAdvancedSample/app/build.gradle
+++ b/NavigationAdvancedSample/app/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation deps.support.design
     implementation deps.support.core_ktx
     implementation deps.constraint_layout
+    implementation deps.arch_core.runtime
 
     // Navigation
     implementation deps.navigation.runtime_ktx

--- a/NavigationAdvancedSample/versions.gradle
+++ b/NavigationAdvancedSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/NavigationBasicSample/versions.gradle
+++ b/NavigationBasicSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/PagingSample/versions.gradle
+++ b/PagingSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/PagingWithNetworkSample/versions.gradle
+++ b/PagingWithNetworkSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/PersistenceContentProviderSample/versions.gradle
+++ b/PersistenceContentProviderSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/PersistenceMigrationsSample/versions.gradle
+++ b/PersistenceMigrationsSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/WorkManagerSample/app/build.gradle
+++ b/WorkManagerSample/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation deps.support.design
     implementation deps.support.v4
     implementation deps.constraint_layout
+    implementation deps.arch_core.runtime
     implementation deps.retrofit.runtime
     implementation deps.retrofit.gson
     implementation deps.okhttp_logging_interceptor

--- a/WorkManagerSample/versions.gradle
+++ b/WorkManagerSample/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos

--- a/versions.gradle
+++ b/versions.gradle
@@ -24,7 +24,7 @@ ext.deps = [:]
 def versions = [:]
 versions.android_gradle_plugin = '3.3.1'
 versions.apache_commons = "2.5"
-versions.arch_core = "2.0.0"
+versions.arch_core = "2.0.1"
 versions.atsl_rules = "1.1.0-alpha4"
 versions.atsl_runner = "1.1.0-alpha4"
 versions.constraint_layout = "2.0.0-alpha2"
@@ -45,7 +45,7 @@ versions.navigation = "2.1.0-alpha01"
 versions.okhttp_logging_interceptor = "3.9.0"
 versions.paging = "2.1.0-rc01"
 versions.retrofit = "2.3.0"
-versions.room = "2.1.0-alpha03"
+versions.room = "2.1.0-alpha06"
 versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
@@ -80,6 +80,7 @@ lifecycle.compiler = "androidx.lifecycle:lifecycle-compiler:$versions.lifecycle"
 deps.lifecycle = lifecycle
 
 def arch_core = [:]
+arch_core.runtime = "androidx.arch.core:core-runtime:$versions.arch_core"
 arch_core.testing = "androidx.arch.core:core-testing:$versions.arch_core"
 deps.arch_core = arch_core
 
@@ -170,5 +171,6 @@ def addRepos(RepositoryHandler handler) {
     handler.google()
     handler.jcenter()
     handler.maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    handler.maven { url "https://kotlin.bintray.com/kotlinx/" } // For kotlinx-metadata-jvm used by Room 2.1.0 (KT-27991)
 }
 ext.addRepos = this.&addRepos


### PR DESCRIPTION
Additionally bump androidx.arch.core to 2.0.1 and add it as a dependency in WorkManagerSample and NavigationAdvanceSample to avoid conflicting versions between app and test variant.