### PR TITLE
Fix workmanager build

### DIFF
--- a/WorkManagerSample/benchmark/build.gradle
+++ b/WorkManagerSample/benchmark/build.gradle
@@ -34,5 +34,4 @@ dependencies {
     androidTestImplementation deps.benchmark
     androidTestImplementation deps.espresso.core
     androidTestImplementation deps.work.testing
-    androidTestImplementation deps.arch_core.testing
 }

--- a/WorkManagerSample/benchmark/src/androidTest/java/com/example/benchmark/WorkerBenchmark.kt
+++ b/WorkManagerSample/benchmark/src/androidTest/java/com/example/benchmark/WorkerBenchmark.kt
@@ -1,7 +1,6 @@
 package com.example.benchmark
 
 import android.graphics.BitmapFactory
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.benchmark.BenchmarkRule
 import androidx.benchmark.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -26,9 +25,6 @@ class WorkerBenchmark {
 
     @get:Rule
     val benchmarkRule = BenchmarkRule()
-
-    @get:Rule
-    var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     @Test
     fun testBlurEffectFilterWorker() {

--- a/WorkManagerSample/lib/src/main/AndroidManifest.xml
+++ b/WorkManagerSample/lib/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.background" />
+<manifest package="com.example.lib" />

--- a/WorkManagerSample/lib/src/main/AndroidManifest.xml
+++ b/WorkManagerSample/lib/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="com.example.lib" />
+<manifest package="com.example.background.library" />


### PR DESCRIPTION
Remove an unused rule

The applyFilter method is synchronous anyway?