### PR TITLE
Deprecated API are replaced

### DIFF
--- a/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/LocalUserDataSourceTest.java
+++ b/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/LocalUserDataSourceTest.java
@@ -18,7 +18,8 @@ package com.example.android.observability.persistence;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,7 +42,7 @@ public class LocalUserDataSourceTest {
     public void initDb() {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(),
                 UsersDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()

--- a/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.java
+++ b/BasicRxJavaSample/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.java
@@ -18,7 +18,7 @@ package com.example.android.observability.persistence;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -43,7 +43,7 @@ public class UserDaoTest {
     public void initDb() {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(),
                 UsersDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()

--- a/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt
+++ b/BasicRxJavaSampleKotlin/app/src/androidTest/java/com/example/android/observability/persistence/UserDaoTest.kt
@@ -18,7 +18,7 @@ package com.example.android.observability.persistence
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.runner.AndroidJUnit4
 import org.junit.After
 import org.junit.Before
@@ -38,7 +38,7 @@ class UserDaoTest {
 
     @Before fun initDb() {
         // using an in-memory database because the information stored here disappears after test
-        database = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        database = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(),
                 UsersDatabase::class.java)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()

--- a/BasicSample/app/src/androidTest/java/com/example/android/persistence/db/CommentDaoTest.java
+++ b/BasicSample/app/src/androidTest/java/com/example/android/persistence/db/CommentDaoTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.assertThat;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
 import android.database.sqlite.SQLiteConstraintException;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import com.example.android.persistence.LiveDataTestUtil;
 import com.example.android.persistence.db.dao.CommentDao;
@@ -63,7 +63,7 @@ public class CommentDaoTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(),
                 AppDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()

--- a/BasicSample/app/src/androidTest/java/com/example/android/persistence/db/ProductDaoTest.java
+++ b/BasicSample/app/src/androidTest/java/com/example/android/persistence/db/ProductDaoTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import com.example.android.persistence.LiveDataTestUtil;
 import com.example.android.persistence.db.dao.ProductDao;
@@ -56,7 +56,7 @@ public class ProductDaoTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(),
                 AppDatabase.class)
                 // allowing main thread queries, just for testing
                 .allowMainThreadQueries()

--- a/BasicSample/app/src/androidTest/java/com/example/android/persistence/ui/MainActivityTest.java
+++ b/BasicSample/app/src/androidTest/java/com/example/android/persistence/ui/MainActivityTest.java
@@ -26,7 +26,7 @@ import androidx.arch.core.executor.testing.CountingTaskExecutorRule;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 import androidx.annotation.Nullable;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
@@ -54,7 +54,7 @@ public class MainActivityTest {
 
     public MainActivityTest() {
         // delete the database
-        InstrumentationRegistry.getTargetContext().deleteDatabase(AppDatabase.DATABASE_NAME);
+        ApplicationProvider.getApplicationContext().deleteDatabase(AppDatabase.DATABASE_NAME);
     }
 
     @Before
@@ -66,7 +66,7 @@ public class MainActivityTest {
     @Before
     public void waitForDbCreation() throws Throwable {
         final CountDownLatch latch = new CountDownLatch(1);
-        final LiveData<Boolean> databaseCreated = AppDatabase.getInstance(InstrumentationRegistry.getTargetContext(), new AppExecutors()).getDatabaseCreated();
+        final LiveData<Boolean> databaseCreated = AppDatabase.getInstance(ApplicationProvider.getApplicationContext(), new AppExecutors()).getDatabaseCreated();
         mActivityRule.runOnUiThread(new Runnable() {
 
             @Override

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/db/DbTest.kt
@@ -19,7 +19,7 @@ package com.android.example.github.db
 
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule
 import androidx.room.Room
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -36,7 +36,7 @@ abstract class DbTest {
     @Before
     fun initDb() {
         _db = Room.inMemoryDatabaseBuilder(
-            InstrumentationRegistry.getContext(),
+            ApplicationProvider.getApplicationContext()(),
             GithubDb::class.java
         ).build()
     }

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/ui/repo/RepoFragmentTest.kt
@@ -19,7 +19,7 @@ package com.android.example.github.ui.repo
 import androidx.lifecycle.MutableLiveData
 import androidx.databinding.DataBindingComponent
 import androidx.annotation.StringRes
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -208,7 +208,7 @@ class RepoFragmentTest {
     }
 
     private fun getString(@StringRes id: Int, vararg args: Any): String {
-        return InstrumentationRegistry.getTargetContext().getString(id, *args)
+        return ApplicationProvider.getApplicationContext()().getString(id, *args)
     }
 
     class TestRepoFragment : RepoFragment() {

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/AutoClearedValueTest.kt
@@ -15,7 +15,7 @@
  */
 package com.android.example.github.util
 
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
 import androidx.fragment.app.DialogFragment

--- a/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/DataBindingIdlingResourceTest.kt
+++ b/GithubBrowserSample/app/src/androidTest/java/com/android/example/github/util/DataBindingIdlingResourceTest.kt
@@ -19,7 +19,7 @@ package com.android.example.github.util
 import androidx.databinding.DataBindingComponent
 import androidx.databinding.ViewDataBinding
 import android.os.Bundle
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource

--- a/PagingSample/app/src/androidTest/java/paging/android/example/com/pagingsample/MainActivityTest.java
+++ b/PagingSample/app/src/androidTest/java/paging/android/example/com/pagingsample/MainActivityTest.java
@@ -19,7 +19,7 @@ package paging.android.example.com.pagingsample;
 import android.app.Activity;
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule;
 import android.content.Intent;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -45,7 +45,7 @@ public class MainActivityTest {
 
     @Test
     public void showSomeResults() throws InterruptedException, TimeoutException {
-        Intent intent = new Intent(InstrumentationRegistry.getTargetContext(), MainActivity.class);
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext()(), MainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         Activity activity = InstrumentationRegistry.getInstrumentation().startActivitySync(intent);
         testRule.drainTasks(10, TimeUnit.SECONDS);

--- a/PagingWithNetworkSample/app/src/androidTest/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivityTest.kt
+++ b/PagingWithNetworkSample/app/src/androidTest/java/com/android/example/paging/pagingwithnetwork/reddit/ui/RedditActivityTest.kt
@@ -19,7 +19,7 @@ package com.android.example.paging.pagingwithnetwork.reddit.ui
 import android.app.Application
 import android.content.Intent
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule
-import androidx.test.InstrumentationRegistry
+import androidx.test.core.app.ApplicationProvider
 import androidx.recyclerview.widget.RecyclerView
 import com.android.example.paging.pagingwithnetwork.R
 import com.android.example.paging.pagingwithnetwork.reddit.DefaultServiceLocator
@@ -62,7 +62,7 @@ class RedditActivityTest(private val type: RedditPostRepository.Type) {
         fakeApi.addPost(postFactory.createRedditPost(DEFAULT_SUBREDDIT))
         fakeApi.addPost(postFactory.createRedditPost(DEFAULT_SUBREDDIT))
         fakeApi.addPost(postFactory.createRedditPost(DEFAULT_SUBREDDIT))
-        val app = InstrumentationRegistry.getTargetContext().applicationContext as Application
+        val app = ApplicationProvider.getApplicationContext()().applicationContext as Application
         // use a controlled service locator w/ fake API
         ServiceLocator.swap(
                 object : DefaultServiceLocator(app = app,
@@ -76,7 +76,7 @@ class RedditActivityTest(private val type: RedditPostRepository.Type) {
     @Throws(InterruptedException::class, TimeoutException::class)
     fun showSomeResults() {
         val intent = RedditActivity.intentFor(
-                context = InstrumentationRegistry.getTargetContext(),
+                context = ApplicationProvider.getApplicationContext()(),
                 type = type)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         val activity = InstrumentationRegistry.getInstrumentation().startActivitySync(intent)

--- a/PersistenceContentProviderSample/app/src/androidTest/java/com/example/android/contentprovidersample/CheeseTest.java
+++ b/PersistenceContentProviderSample/app/src/androidTest/java/com/example/android/contentprovidersample/CheeseTest.java
@@ -19,7 +19,7 @@ package com.example.android.contentprovidersample;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
 import androidx.test.runner.AndroidJUnit4;
 import com.example.android.contentprovidersample.data.Cheese;
@@ -41,7 +41,7 @@ public class CheeseTest {
 
     @Before
     public void createDatabase() {
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getTargetContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext()(),
                 SampleDatabase.class).build();
     }
 

--- a/PersistenceContentProviderSample/app/src/androidTest/java/com/example/android/contentprovidersample/SampleContentProviderTest.java
+++ b/PersistenceContentProviderSample/app/src/androidTest/java/com/example/android/contentprovidersample/SampleContentProviderTest.java
@@ -29,7 +29,7 @@ import android.content.OperationApplicationException;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.RemoteException;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.filters.SmallTest;
 import androidx.test.runner.AndroidJUnit4;
 import com.example.android.contentprovidersample.data.Cheese;
@@ -51,7 +51,7 @@ public class SampleContentProviderTest {
 
     @Before
     public void setUp() {
-        final Context context = InstrumentationRegistry.getTargetContext();
+        final Context context = ApplicationProvider.getApplicationContext()();
         SampleDatabase.switchToInMemory(context);
         mContentResolver = context.getContentResolver();
     }

--- a/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
@@ -20,7 +20,7 @@ import static junit.framework.Assert.assertNull;
 
 import static org.junit.Assert.assertEquals;
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +39,7 @@ public class LocalUserDataSourceTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class).build();
         mDataSource = new LocalUserDataSource(mDatabase.userDao());
     }

--- a/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/MigrationTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/MigrationTest.java
@@ -26,7 +26,7 @@ import androidx.room.Room;
 import androidx.room.testing.MigrationTestHelper;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +60,7 @@ public class MigrationTest {
     public void setUp() throws Exception {
         // To test migrations from version 1 of the database, we need to create the database
         // with version 1 using SQLite API
-        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(InstrumentationRegistry.getTargetContext(),
+        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(ApplicationProvider.getApplicationContext()(),
                 TEST_DB_NAME);
         // We're creating the table for every test, to ensure that the table is in the correct state
         SqliteDatabaseTestHelper.createTable(mSqliteTestDbHelper);
@@ -106,7 +106,7 @@ public class MigrationTest {
     }
 
     private UsersDatabase getMigratedRoomDatabase() {
-        UsersDatabase database = Room.databaseBuilder(InstrumentationRegistry.getTargetContext(),
+        UsersDatabase database = Room.databaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class, TEST_DB_NAME)
                 .addMigrations(MIGRATION_1_2)
                 .build();

--- a/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/UserDaoTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom/java/com/example/android/persistence/migrations/UserDaoTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -41,7 +41,7 @@ public class UserDaoTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class).build();
     }
 

--- a/PersistenceMigrationsSample/app/src/androidTestRoom2/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom2/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public class LocalUserDataSourceTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class).build();
         mDataSource = new LocalUserDataSource(mDatabase.userDao());
     }

--- a/PersistenceMigrationsSample/app/src/androidTestRoom2/java/com/example/android/persistence/migrations/MigrationTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom2/java/com/example/android/persistence/migrations/MigrationTest.java
@@ -27,7 +27,7 @@ import androidx.room.Room;
 import androidx.room.testing.MigrationTestHelper;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -63,7 +63,7 @@ public class MigrationTest {
     public void setUp() throws Exception {
         // To test migrations from version 1 of the database, we need to create the database
         // with version 1 using SQLite API
-        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(InstrumentationRegistry.getTargetContext(),
+        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(ApplicationProvider.getApplicationContext()(),
                 TEST_DB_NAME);
         // We're creating the table for every test, to ensure that the table is in the correct state
         SqliteDatabaseTestHelper.createTable(mSqliteTestDbHelper);
@@ -136,7 +136,7 @@ public class MigrationTest {
     }
 
     private UsersDatabase getMigratedRoomDatabase() {
-        UsersDatabase database = Room.databaseBuilder(InstrumentationRegistry.getTargetContext(),
+        UsersDatabase database = Room.databaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class, TEST_DB_NAME)
                 .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                 .build();

--- a/PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import androidx.room.Room;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public class LocalUserDataSourceTest {
     public void initDb() throws Exception {
         // using an in-memory database because the information stored here disappears when the
         // process is killed
-        mDatabase = Room.inMemoryDatabaseBuilder(InstrumentationRegistry.getContext(),
+        mDatabase = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class).build();
         mDataSource = new LocalUserDataSource(mDatabase.userDao());
     }

--- a/PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/MigrationTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestRoom3/java/com/example/android/persistence/migrations/MigrationTest.java
@@ -30,7 +30,7 @@ import androidx.room.Room;
 import androidx.room.testing.MigrationTestHelper;
 import android.content.ContentValues;
 import android.database.sqlite.SQLiteDatabase;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -67,7 +67,7 @@ public class MigrationTest {
     public void setUp() throws Exception {
         // To test migrations from version 1 of the database, we need to create the database
         // with version 1 using SQLite API
-        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(InstrumentationRegistry.getTargetContext(),
+        mSqliteTestDbHelper = new SqliteTestDbOpenHelper(ApplicationProvider.getApplicationContext()(),
                 TEST_DB_NAME);
         // We're creating the table for every test, to ensure that the table is in the correct state
         SqliteDatabaseTestHelper.createTable(mSqliteTestDbHelper);
@@ -160,7 +160,7 @@ public class MigrationTest {
     }
 
     private UsersDatabase getMigratedRoomDatabase() {
-        UsersDatabase database = Room.databaseBuilder(InstrumentationRegistry.getTargetContext(),
+        UsersDatabase database = Room.databaseBuilder(ApplicationProvider.getApplicationContext()(),
                 UsersDatabase.class, TEST_DB_NAME)
                 .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_1_4)
                 .build();

--- a/PersistenceMigrationsSample/app/src/androidTestSqlite/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
+++ b/PersistenceMigrationsSample/app/src/androidTestSqlite/java/com/example/android/persistence/migrations/LocalUserDataSourceTest.java
@@ -19,7 +19,7 @@ package com.example.android.persistence.migrations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.runner.AndroidJUnit4;
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +38,7 @@ public class LocalUserDataSourceTest {
 
     @Before
     public void initDb() throws Exception {
-        mDataSource = LocalUserDataSource.getInstance(InstrumentationRegistry.getTargetContext());
+        mDataSource = LocalUserDataSource.getInstance(ApplicationProvider.getApplicationContext()());
     }
 
     @After


### PR DESCRIPTION
Deprecated InstrumentationRegistry.getContext() and InstrumentationRegistry.getTargetContext() are replaced with ApplicationProvider.getApplicationContext()