### PR TITLE
Upgrade WorkManagerSample to use 2.1.0 stable.

### DIFF
--- a/BasicRxJavaSample/versions.gradle
+++ b/BasicRxJavaSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/BasicRxJavaSampleKotlin/versions.gradle
+++ b/BasicRxJavaSampleKotlin/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/BasicSample/versions.gradle
+++ b/BasicSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/GithubBrowserSample/versions.gradle
+++ b/GithubBrowserSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/NavigationAdvancedSample/versions.gradle
+++ b/NavigationAdvancedSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/NavigationBasicSample/versions.gradle
+++ b/NavigationBasicSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/PagingSample/versions.gradle
+++ b/PagingSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/PagingWithNetworkSample/versions.gradle
+++ b/PagingWithNetworkSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/PersistenceContentProviderSample/versions.gradle
+++ b/PersistenceContentProviderSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/PersistenceMigrationsSample/versions.gradle
+++ b/PersistenceMigrationsSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/WorkManagerSample/app/build.gradle
+++ b/WorkManagerSample/app/build.gradle
@@ -41,6 +41,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {
@@ -49,6 +52,7 @@ dependencies {
 
     implementation deps.kotlin.stdlib
     implementation deps.work.runtime_ktx
+    implementation deps.lifecycle.extensions
     implementation deps.support.app_compat
     implementation deps.support.cardview
     implementation deps.support.design

--- a/WorkManagerSample/lib/build.gradle
+++ b/WorkManagerSample/lib/build.gradle
@@ -17,6 +17,10 @@ android {
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 dependencies {
@@ -36,4 +40,3 @@ dependencies {
 
     testImplementation deps.junit
 }
-

--- a/WorkManagerSample/versions.gradle
+++ b/WorkManagerSample/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]

--- a/versions.gradle
+++ b/versions.gradle
@@ -54,7 +54,7 @@ versions.rx_android = "2.0.1"
 versions.rxjava2 = "2.1.3"
 versions.support = "1.0.0"
 versions.timber = "4.5.1"
-versions.work = "2.1.0-alpha01"
+versions.work = "2.1.0"
 ext.versions = versions
 
 def deps = [:]


### PR DESCRIPTION
* Add the explicit dependency on lifecycle extensions.
* Add `kotlinJvmOptions` as the `ktx` library targets Java 8.

Change-Id: Icc46cd2a80b2fb9e716a8b2abf7b70961f4d70d6