### PR TITLE
Update the link for Paging to Paging v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of samples using the [Architecture Components](https://developer.an
 - [Lifecycle-aware components](https://developer.android.com/topic/libraries/architecture/lifecycle)
 - [ViewModels](https://developer.android.com/topic/libraries/architecture/viewmodel)
 - [LiveData](https://developer.android.com/topic/libraries/architecture/livedata)
-- [Paging](https://developer.android.com/topic/libraries/architecture/paging/)
+- [Paging](https://developer.android.com/topic/libraries/architecture/paging/v3-overview)
 - [Navigation](https://developer.android.com/topic/libraries/architecture/navigation/)
 - [ViewBinding](https://developer.android.com/topic/libraries/view-binding)
 - [WorkManager](https://developer.android.com/topic/libraries/architecture/workmanager/)


### PR DESCRIPTION
### Summary:

At present, the Paging link will transition to Paging v2, where it will display the warning message:

`Caution: This guide covers an older, deprecated version of the Paging library. For more information about the latest stable version of Paging, see the [Paging 3 guides].`

This PR update the paging link to version 3 ( https://developer.android.com/topic/libraries/architecture/paging/v3-overview ).

### Modifications:

Update the link
+ https://developer.android.com/topic/libraries/architecture/paging/ => https://developer.android.com/topic/libraries/architecture/paging/v3-overview



